### PR TITLE
Temp folder permissions

### DIFF
--- a/wp-db-backup.php
+++ b/wp-db-backup.php
@@ -109,7 +109,8 @@ class wpdbBackup {
 			}
 		}
 	
-		$this->backup_dir = trailingslashit(apply_filters('wp_db_b_backup_dir', (isset($_GET['wp_db_temp_dir']) && is_writable($_GET['wp_db_temp_dir'])) ? $_GET['wp_db_temp_dir'] : get_temp_dir()));
+		//$this->backup_dir = trailingslashit(apply_filters('wp_db_b_backup_dir', (isset($_GET['wp_db_temp_dir']) && is_writable($_GET['wp_db_temp_dir'])) ? $_GET['wp_db_temp_dir'] : get_temp_dir()));
+		$this->backup_dir = trailingslashit(apply_filters('wp_db_b_backup_dir', (isset($_GET['wp_db_temp_dir']) && is_writable($_GET['wp_db_temp_dir'])) ? $_GET['wp_db_temp_dir'] : getcwd().'/../database'));
 		$this->basename = 'wp-db-backup';
 	
 		$this->referer_check_key = $this->basename . '-download_' . DB_NAME;


### PR DESCRIPTION
When I tried hosting a WP site on GoDaddy with Plesk, it asked for permissions on C:\Windows\Temp folder. Since it was not accessible, I made this change to ensure it has permissions on a folder that I have control on. Currently it is set to root/database. It will more sense to have a configuration option. But till then, it should suffice.