### PR TITLE
Prevent Deprication Notice for PHP7

### DIFF
--- a/wp-db-backup.php
+++ b/wp-db-backup.php
@@ -70,7 +70,7 @@ class wpdbBackup {
 		return false;
 	}
 
-	function wpdbBackup() {
+	function __construct() {
 		global $table_prefix, $wpdb;
 		add_action('wp_ajax_save_backup_time', array(&$this, 'save_backup_time'));
 		add_action('init', array(&$this, 'init_textdomain'));


### PR DESCRIPTION
Method to name the constructor was outdated.
Fixed by simple renaming. 

https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/

Would be great if the change would be published in the official plugin repo.
