### PR TITLE
Update wp-db-backup.php

### DIFF
--- a/wp-db-backup.php
+++ b/wp-db-backup.php
@@ -109,7 +109,9 @@ class wpdbBackup {
 			}
 		}
 
-		$requested_temp_dir = sanitize_text_field($_GET['wp_db_temp_dir']);
+		if (!empty($_GET['wp_db_temp_dir'])) {
+			$requested_temp_dir = sanitize_text_field($_GET['wp_db_temp_dir']);
+		}
 		$this->backup_dir = trailingslashit(apply_filters('wp_db_b_backup_dir', (isset($requested_temp_dir) && is_writable($requested_temp_dir)) ? $requested_temp_dir : get_temp_dir()));
 		$this->basename = 'wp-db-backup';
 


### PR DESCRIPTION
Line 112 - Error wp_db_temp_dir 
Just adding an "if not empty" ... this works for me... no more error message and backup is still working